### PR TITLE
Fix b version of home page

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,7 +180,7 @@ def alternate_homepage():
     sticky_posts, _, _ = helpers.get_formatted_expanded_posts(sticky=True)
     featured_posts = sticky_posts[:3] if sticky_posts else None
     page = helpers.to_int(flask.request.args.get('page'), default=1)
-    posts_per_page = 13 if page == 1 else 12
+    posts_per_page = 12
 
     if category_slug:
         categories = api.get_categories(slugs=[category_slug])
@@ -191,13 +191,9 @@ def alternate_homepage():
     posts, total_posts, total_pages = helpers.get_formatted_expanded_posts(
         per_page=posts_per_page,
         category_ids=[category['id']] if category else [],
-        page=page
+        page=page,
+        sticky=False
     )
-
-    if featured_posts:
-        for post in featured_posts:
-            if post in posts:
-                posts.remove(post)
 
     return flask.render_template(
         'alternate_index.html',

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -187,6 +187,10 @@ pre {
     font: inherit;
     padding: $sp-large 0;
 
+    &:focus {
+      outline: none;
+    }
+
     &[aria-expanded='false'],
     &[aria-expanded='true'] {
       background-image: none;

--- a/templates/accordion-signup-form.html
+++ b/templates/accordion-signup-form.html
@@ -1,4 +1,4 @@
-<div class="p-accordion--form" role="tablist">
+<div class="p-accordion--form u-no-margin--top" role="tablist">
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
       <div class="row">

--- a/templates/alternate_index.html
+++ b/templates/alternate_index.html
@@ -13,19 +13,10 @@
 </div>
 {% endif %}
 
-<section class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-12">
-      <h1 class="p-heading--two">
-        Ubuntu news and resources
-      </h1>
-    </div>
-  </div>
-</section>
-
-{% if featured_posts %}{% include "featured-posts.html" %}{% endif %}
-
-{% include "accordion-signup-form.html" %}
+{% if current_page and current_page == 1 %}
+  {% if featured_posts %}{% include "featured-posts.html" %}{% endif %}
+  {% include "accordion-signup-form.html" %}
+{% endif %}
 
 {% include "alternate_posts.html" %}
 


### PR DESCRIPTION
## Done

- Removed 'Ubuntu news and resources' heading
- Removed whitespace between featured posts and newsletter accordion
- Only show featured posts of first page
- Only show accordion on first page
- Removed form accordion outline on focus

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8023/home>
- Check that each of the above issues have been addressed


## Issue / Card

Fixes #366 