### PR TITLE
Updated google tag manager code

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,6 +12,16 @@
         <meta property="og:image" content="https://assets.ubuntu.com/v1/55a39964-ubuntublog-facebook.png" />
       {% endif %}
 
+      <!-- Google Tag Manager -->
+      <script>
+      window.dataLayer = window.dataLayer || [];
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
+      <!-- End Google Tag Manager -->
+
       {% if post.link %}
         <meta property="og:url" content="{{post.link}}" />
       {% endif %}
@@ -54,39 +64,10 @@
   </head>
 
   <body>
-    <!-- Google Optimize page-hiding -->
-    <style>.async-hide { opacity: 0 !important} </style>
-    <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-    })(window,document.documentElement,'async-hide','dataLayer',4000,
-    {'GTM-KWL5RDF':true});</script>
-    <!-- End Google Optimize page-hiding -->
-
-    <!-- Google Analytics and Google Optimize -->
-    <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', 'xt', 'auto', {'allowLinker': true});
-    ga('require', 'GTM-KWL5RDF');
-    ga('require', 'linker');
-    ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',
-    'ubuntu.com', 'insights.ubuntu.com', 'developer.ubuntu.com', 'cn.ubuntu.com',
-    'design.ubuntu.com', 'maas.io', 'canonical.com', 'landscape.canonical.com',
-    'pages.ubuntu.com', 'tutorials.ubuntu.com', 'docs.ubuntu.com']);
-    </script>
-    <!-- End Google Analytics and Google Optimize -->
-
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
-    <!-- End Google Tag Manager -->
+    <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <header id="navigation" class="p-navigation">
       <div class="row">

--- a/templates/post.html
+++ b/templates/post.html
@@ -42,22 +42,22 @@
           Share on:
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://insights.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered }}&amp;p[summary]={{ post.summary }}%26hellip%3B&amp;p[images][0]=">
+          <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com/?p={{ post.id }}&#9;&#9;&#9;&amp;p[title]={{ post.title.rendered }}&amp;p[summary]={{ post.summary }}%26hellip%3B&amp;p[images][0]=">
             Facebook
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ post.title.rendered | safe }}&amp;url=https://insights.ubuntu.com/?p={{ post.id }}&amp;hashtags=ubuntu">
+          <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ post.title.rendered | safe }}&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;hashtags=ubuntu">
             Twitter
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--google" title="Share on google+" href="https://plus.google.com/share?url=https://insights.ubuntu.com/?p={{ post.id }}">
+          <a class="p-icon--google" title="Share on google+" href="https://plus.google.com/share?url=https://blog.ubuntu.com/?p={{ post.id }}">
           Google+
         </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://insights.ubuntu.com/?p={{ post.id }}&amp;title={{ post.title.rendered | safe }}">
+          <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://blog.ubuntu.com/?p={{ post.id }}&amp;title={{ post.title.rendered | safe }}">
           LinkedIn
         </a>
         </li>


### PR DESCRIPTION
## Done

- Updated google tag manager code as we aren't running any optomise tests
- Update some old insights.u.c links on sharing links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
- click https://tagmanager.google.com/scc/?uiv2&id=GTM-K92JCQ&gtm_preview=env-73&gtm_debug=x&url=http://0.0.0.0:8023/&gtm_env_name=Draft+Environment+72+2016-11-30+08:50:34 and see that the GTM is working

