### PR TITLE
Re-add GTM to non-post pages

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,22 +5,23 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+    <!-- Google Tag Manager -->
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
+    <!-- End Google Tag Manager -->
+    
     {% if post %}
       {% if post.featuredmedia %}
         <meta property="og:image" content="{{post.featuredmedia.source_url}}" />
       {% else %}
         <meta property="og:image" content="https://assets.ubuntu.com/v1/55a39964-ubuntublog-facebook.png" />
       {% endif %}
-
-      <!-- Google Tag Manager -->
-      <script>
-      window.dataLayer = window.dataLayer || [];
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
-      <!-- End Google Tag Manager -->
 
       {% if post.link %}
         <meta property="og:url" content="{{post.link}}" />


### PR DESCRIPTION
## Done

Ensuring GTM also appears on non-post pages

During the recent GTM/Optimize cleanup (#388 ), the GTM code was moved inside the `{% if post %}` block which removed GA from the homepage, category pages, press centre... This PR fixes it.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Look at the source of non-post pages and ensure the GTM JS is present near the top.
