### PR TITLE
Add net-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip
+RUN apt-get update && apt-get install --yes python3-pip net-tools
 
 # Python dependencies
 ENV LANG C.UTF-8


### PR DESCRIPTION
This is so we can use `netstat` in a `livenessProbe` to check a process is running on port 80.