### PR TITLE
Upgrade Flask, extend timeout

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -104,7 +104,7 @@ def cached_request(url):
     If it gets an error, it will use the cached response, if it exists.
     """
 
-    response = cached_session.get(url, timeout=2)
+    response = cached_session.get(url, timeout=3)
 
     try:
         response.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
 feedparser==5.2.1
-Flask==0.12.2
+Flask==1.0.2
 humanize==0.5.1
 idna==2.6
 itsdangerous==0.24


### PR DESCRIPTION
Upgrade Flask to latest

Increase feed timeout to 3 seconds

We are frequently getting feed timeout errors in the logs, e.g.:

```
[2018-08-30 13:34:58,217] ERROR in app: Exception on
/2018/08/28/fresh-linux-applications-on-demand [GET] Traceback (most recent
call last):
 File "/usr/local/lib/python3.5/dist-packages/urllib3/connectionpool.py",
line 387, in _make_request
six.raise_from(e, None)
File "<string>", line 2, in raise_from
File "/usr/local/lib/python3.5/dist-packages/urllib3/connectionpool.py",
line 383, in _make_request
    httplib_response = conn.getresponse()
File "/usr/lib/python3.5/http/client.py", line 1197, in getresponse
    response.begin()
File "/usr/lib/python3.5/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
File "/usr/lib/python3.5/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
File "/usr/lib/python3.5/socket.py", line 575, in readinto
    return self._sock.recv_into(b)
File "/usr/lib/python3.5/ssl.py", line 929, in recv_into
    return self.read(nbytes, buffer)
File "/usr/lib/python3.5/ssl.py", line 791, in read
    return self._sslobj.read(len, buffer)
File "/usr/lib/python3.5/ssl.py", line 575, in read
    v = self._sslobj.read(len, buffer) socket.timeout: The read operation
timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/usr/local/lib/python3.5/dist-packages/urllib3/connectionpool.py",
line 601, in urlopen
    chunked=chunked)
File "/usr/local/lib/python3.5/dist-packages/urllib3/connectionpool.py",
line 389, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
File "/usr/local/lib/python3.5/dist-packages/urllib3/connectionpool.py",
line 309, in _raise_timeout
    raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" %
timeout_value) urllib3.exceptions.ReadTimeoutError:
HTTPSConnectionPool(host='admin.insights.ubuntu.com', port=443): Read timed
out. (read timeout=2)
```

The long term fix is to have a smarter, asynchronous caching layer, but for
now let's just try increasing the timeout to 3 seconds.

QA
--

Check the test passes.

`./run`, thoroughly check the site runs okay.