### PR TITLE
Add CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # blog.ubuntu.com
+
+[![CircleCI build status](https://circleci.com/gh/canonical-websites/blog.ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-websites/blog.ubuntu.com)
+
 A Flask frontend for the insights.ubuntu.com website.


### PR DESCRIPTION
## Done

Added CircleCI badge to blog.ubuntu.com.

## QA

Go to https://github.com/jpmartinspt/blog.ubuntu.com/tree/add_badges and check the CircleCI badge is now showing when you browse the readme.

## Issues

Fixes https://github.com/ubuntudesign/base-squad/issues/294
