### PR TITLE
Update cookie policy dep to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Canonical webteam",
   "devDependencies": {
     "autoprefixer": "9.4.7",
-    "cookie-policy": "1.0.6",
+    "cookie-policy": "1.1.0",
     "global-nav": "2.0.0",
     "node-sass": "4.11.0",
     "postcss-cli": "6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,9 +1193,9 @@ convert-source-map@^1.1.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie-policy@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-policy/-/cookie-policy-1.0.6.tgz#8dbaf12bd5b0c300a4147e8e1ce95eb911741725"
+cookie-policy@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cookie-policy/-/cookie-policy-1.1.0.tgz#759380282c8af118560a99bcb37c50ab039dd899"
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.2.2"


### PR DESCRIPTION
## Done
Bump cookie policy v1.1.0

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Check the cookie policy no longer effects the search button styling
