### PR TITLE
Remove black and flake8 dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: canonicalwebteam/dev
+    - image: canonicalwebteam/dev:v1.6.3
 
 jobs:
   test-site:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies
-          command: pip install flake8 black
-      - run:
           name: Lint python code
           command: yarn lint-python
   test-python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,3 @@ raven[flask]==6.10.0
 prometheus_client==0.3.1
 talisker==0.11.1
 
-# Development dependencies
-flake8
-black

--- a/run
+++ b/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.1"
+dev_image="canonicalwebteam/dev:v1.6.3"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi


### PR DESCRIPTION
We can't install black and flake8 during the build process. So we should remove them from `requirements.txt`.

I've also updated the `./run` script, and done some other tidying.

QA
--

``` bash
./run clean
./run build
./run test
./run
```

Check the site works.