### PR TITLE
Remove cache when expired on request

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -119,4 +119,6 @@ def cached_request(url):
             domain=urlparse(url).netloc, code=response.status_code
         ).observe(response.elapsed.total_seconds())
 
+    cached_session.remove_expired_responses()
+
     return response


### PR DESCRIPTION
# Summary

Remove cache when expired (done on request) this causes Disk I/O errors 

https://requests-cache.readthedocs.io/en/latest/user_guide.html#expiration

https://sentry.is.canonical.com/canonical/blog-ubuntu-com/issues/975/

# QA

- `./run`
- Have fun on the website and check cache size 