### PR TITLE
Alters checkbox label to clarify that it’s optional

### DIFF
--- a/templates/newsletter-form.html
+++ b/templates/newsletter-form.html
@@ -37,7 +37,7 @@
         <span class="mktInput mktLblRight">
           <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
           <label for="canonicalUpdatesOptIn">
-            <small>I agree to receive information about Canonical’s products and services.</small>
+            <small>Also notify me of events and new products</small>
           </span>
           <span class="mktFormMsg"></span>
         </span>


### PR DESCRIPTION
## Done

- Changes “I agree to receive information about Canonical’s products and services.” to “Also notify me of events and new products”

In detail:
- “Also”: clarifies that the checkbox is distinct from what else you’re subscribing to. It also avoids the need to label the checkbox as “(optional)”.
- “notify me of”: Shorter, and more assertive, than “I agree to receive information about”.
- “events and new products”: a summary of @caldav’s “an event, a webinar, a product launch, etc.”.
- “.”: A checkbox label should not end with a full stop.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8023/](http://0.0.0.0:8023/)
- Scroll to the bottom of the “Newsletter signup” form.

## Issue / Card

Fixes #437.